### PR TITLE
CI: Add GitHub actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,29 @@
+name: Go
+on: [push, pull_request]
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.13' ]
+
+    steps:
+
+    - name: Set up Go ${{ matrix.go }}
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go }}
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
+    # Go modules needs the bzr binary because of the dependency on launchpad.net/gocheck.
+    # https://github.com/actions/setup-go/issues/18
+    - name: Prepare
+      run: sudo apt-get install bzr
+
+    - name: Build
+      run: make


### PR DESCRIPTION
This invokes 'make' and ensures that all dependencies are installed. Especially bzr is required as otherwise 'make' fails. 

The strategy matrix is already added to allow future Go version being added and tested automatically.

![Screen Shot 2019-12-16 at 11 28 16](https://user-images.githubusercontent.com/382049/70899567-2e285600-1ff7-11ea-8183-8e6d7bbad490.png)

I wouldn't suggest to use Travis CI anymore. Other options would be integrations with Circle CI or GitLab CI.

refs #13