### PR TITLE
Add more information to error logs

### DIFF
--- a/ssl_exporter.go
+++ b/ssl_exporter.go
@@ -75,7 +75,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 	state, err := e.prober(e.target, e.module, e.timeout)
 	if err != nil {
-		log.Errorln(err)
+		log.Errorf("error=%s target=%s prober=%s timeout=%s", err, e.target, e.module.Prober, e.timeout)
 		ch <- prometheus.MustNewConstMetric(
 			tlsConnectSuccess, prometheus.GaugeValue, 0,
 		)
@@ -90,7 +90,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	// Retrieve certificates from the connection state
 	peerCertificates := state.PeerCertificates
 	if len(peerCertificates) < 1 {
-		log.Errorln("No certificates found in connection state for " + e.target)
+		log.Errorf("error=No certificates found in connection state. target=%s prober=%s", e.target, e.module.Prober)
 		ch <- prometheus.MustNewConstMetric(
 			tlsConnectSuccess, prometheus.GaugeValue, 0,
 		)


### PR DESCRIPTION
```
ERRO[0004] error=x509: certificate signed by unknown authority target=untrusted-root.badssl.com:443 prober=tcp timeout=10s  source="ssl_exporter.go:78"
ERRO[0007] error=x509: certificate has expired or is not yet valid: current time 2020-09-04T07:33:57+01:00 is after 2015-04-12T23:59:59Z target=expired.badssl.com:443 prober=tcp timeout=10s  source="ssl_exporter.go:78"
ERRO[0033] error=x509: certificate has expired or is not yet valid: current time 2020-09-04T07:34:23+01:00 is after 2020-08-04T23:59:59Z target=aaaaaaaaa.com:443 prober=tcp timeout=10s  source="ssl_exporter.go:78"
ERRO[0039] error=dial tcp 104.171.23.70:443: connect: connection refused target=aaaaaaaaaa.com:443 prober=tcp timeout=10s  source="ssl_exporter.go:78"
```