### PR TITLE
Support getting certificate information from a kubeconfig file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ which allows for informational dashboards and flexible alert routing.
     - [HTTPS](#https)
     - [File](#file)
     - [Kubernetes](#kubernetes)
+    - [Kubeconfig](#kubeconfig)
   - [Configuration file](#configuration-file)
     - [&lt;module&gt;](#module)
     - [&lt;tls_config&gt;](#tls_config)
@@ -86,6 +87,8 @@ Flags:
 | ssl_file_cert_not_before       | The date before which a certificate found by the file prober is not valid. Expressed as a Unix Epoch Time.       | file, serial_no, issuer_cn, cn, dnsnames, ips, emails, ou                   | file       |
 | ssl_kubernetes_cert_not_after  | The date after which a certificate found by the kubernetes prober expires. Expressed as a Unix Epoch Time.       | namespace, secret, key, serial_no, issuer_cn, cn, dnsnames, ips, emails, ou | kubernetes |
 | ssl_kubernetes_cert_not_before | The date before which a certificate found by the kubernetes prober is not valid. Expressed as a Unix Epoch Time. | namespace, secret, key, serial_no, issuer_cn, cn, dnsnames, ips, emails, ou | kubernetes |
+| ssl_kubeconfig_cert_not_after  | The date after which a certificate found by the kubeconfig prober expires. Expressed as a Unix Epoch Time.       | kubeconfig, name, type, serial_no, issuer_cn, cn, dnsnames, ips, emails, ou | kubeconfig |
+| ssl_kubeconfig_cert_not_before | The date before which a certificate found by the kubeconfig prober is not valid. Expressed as a Unix Epoch Time. | kubeconfig, name, type, serial_no, issuer_cn, cn, dnsnames, ips, emails, ou | kubeconfig |
 | ssl_ocsp_response_next_update  | The nextUpdate value in the OCSP response. Expressed as a Unix Epoch Time                                        |                                                                             | tcp, https |
 | ssl_ocsp_response_produced_at  | The producedAt value in the OCSP response. Expressed as a Unix Epoch Time                                        |                                                                             | tcp, https |
 | ssl_ocsp_response_revoked_at   | The revocationTime value in the OCSP response. Expressed as a Unix Epoch Time                                    |                                                                             | tcp, https |
@@ -229,6 +232,38 @@ sources in the following order:
 - The default configuration file (`$HOME/.kube/config`)
 - The in-cluster environment, if running in a pod
 
+### Kubeconfig
+
+The `kubeconfig` prober exports `ssl_kubeconfig_cert_not_after` and
+`ssl_kubeconfig_cert_not_before` for PEM encoded certificates found in the specified kubeconfig file.
+
+Kubeconfigs local to the exporter can be scraped by providing them as the target
+parameter:
+
+```
+curl "localhost:9219/probe?module=kubeconfig&target=/etc/kubernetes/admin.conf"
+```
+
+One specific usage of this prober could be to run the exporter as a DaemonSet in
+Kubernetes and then scrape each instance to check the expiry of certificates on
+each node:
+
+```yml
+scrape_configs:
+  - job_name: "ssl-kubernetes-kubeconfig"
+    metrics_path: /probe
+    params:
+      module: ["kubeconfig"]
+      target: ["/etc/kubernetes/admin.conf"]
+    kubernetes_sd_configs:
+      - role: node
+    relabel_configs:
+      - source_labels: [__address__]
+        regex: ^(.*):(.*)$
+        target_label: __address__
+        replacement: ${1}:9219
+```
+
 ## Configuration file
 
 You can provide further module configuration by providing the path to a
@@ -242,7 +277,7 @@ modules: [<module>]
 ### \<module\>
 
 ```
-# The type of probe (https, tcp, file, kubernetes)
+# The type of probe (https, tcp, file, kubernetes, kubeconfig)
 prober: <prober_string>
 
 # How long the probe will wait before giving up.

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,9 @@ var (
 			"kubernetes": Module{
 				Prober: "kubernetes",
 			},
+			"kubeconfig": Module{
+				Prober: "kubeconfig",
+			},
 		},
 	}
 )

--- a/examples/ssl_exporter.yaml
+++ b/examples/ssl_exporter.yaml
@@ -36,3 +36,5 @@ modules:
     prober: kubernetes
     kubernetes:
       kubeconfig: /root/.kube/config
+  kubeconfig:
+    prober: kubeconfig

--- a/prober/kubeconfig.go
+++ b/prober/kubeconfig.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/ribbybibby/ssl_exporter/config"
@@ -54,7 +53,7 @@ func ProbeKubeconfig(ctx context.Context, target string, module config.Module, r
 			continue
 		}
 		// Path is relative to kubeconfig path
-		if !strings.HasPrefix(c.Cluster.CertificateAuthority, "/") {
+		if !filepath.IsAbs(c.Cluster.CertificateAuthority) {
 			newPath := filepath.Join(filepath.Dir(k.Path), c.Cluster.CertificateAuthority)
 			c.Cluster.CertificateAuthority = newPath
 		}
@@ -64,7 +63,7 @@ func ProbeKubeconfig(ctx context.Context, target string, module config.Module, r
 			continue
 		}
 		// Path is relative to kubeconfig path
-		if !strings.HasPrefix(u.User.ClientCertificate, "/") {
+		if !filepath.IsAbs(u.User.ClientCertificate) {
 			newPath := filepath.Join(filepath.Dir(k.Path), u.User.ClientCertificate)
 			u.User.ClientCertificate = newPath
 		}

--- a/prober/kubeconfig.go
+++ b/prober/kubeconfig.go
@@ -1,0 +1,71 @@
+package prober
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/ribbybibby/ssl_exporter/config"
+	"gopkg.in/yaml.v2"
+)
+
+type KubeConfigCluster struct {
+	Name    string
+	Cluster KubeConfigClusterCert
+}
+
+type KubeConfigClusterCert struct {
+	CertificateAuthority     string `yaml:"certificate-authority"`
+	CertificateAuthorityData string `yaml:"certificate-authority-data"`
+}
+
+type KubeConfigUser struct {
+	Name string
+	User KubeConfigUserCert
+}
+
+type KubeConfigUserCert struct {
+	ClientCertificate     string `yaml:"client-certificate"`
+	ClientCertificateData string `yaml:"client-certificate-data"`
+}
+
+type KubeConfig struct {
+	Path     string
+	Clusters []KubeConfigCluster
+	Users    []KubeConfigUser
+}
+
+// ProbeKubeconfig collects certificate metrics from kubeconfig files
+func ProbeKubeconfig(ctx context.Context, target string, module config.Module, registry *prometheus.Registry) error {
+	if _, err := os.Stat(target); err != nil {
+		return fmt.Errorf("kubeconfig not found: %s", target)
+	}
+	k, err := ParseKubeConfig(target)
+	if err != nil {
+		return err
+	}
+	k.Path = target
+	err = collectKubeconfigMetrics(*k, registry)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func ParseKubeConfig(file string) (*KubeConfig, error) {
+	k := &KubeConfig{}
+
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	err = yaml.Unmarshal([]byte(data), k)
+	if err != nil {
+		return nil, err
+	}
+
+	return k, nil
+}

--- a/prober/kubeconfig_test.go
+++ b/prober/kubeconfig_test.go
@@ -1,0 +1,155 @@
+package prober
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ribbybibby/ssl_exporter/config"
+	"github.com/ribbybibby/ssl_exporter/test"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/yaml.v2"
+)
+
+// TestProbeFile tests a file
+func TestProbeKubeconfig(t *testing.T) {
+	cert, kubeconfig, err := createTestKubeconfig("", "kubeconfig")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer os.Remove(kubeconfig)
+
+	module := config.Module{}
+
+	registry := prometheus.NewRegistry()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := ProbeKubeconfig(ctx, kubeconfig, module, registry); err != nil {
+		t.Fatalf("error: %s", err)
+	}
+
+	checkKubeconfigMetrics(cert, kubeconfig, registry, t)
+}
+
+// Create a certificate and write it to a file
+func createTestKubeconfig(dir, filename string) (*x509.Certificate, string, error) {
+	certPEM, _ := test.GenerateTestCertificate(time.Now().Add(time.Hour * 1))
+	clusterCert := KubeConfigClusterCert{CertificateAuthorityData: base64.StdEncoding.EncodeToString([]byte(certPEM))}
+	clusters := []KubeConfigCluster{KubeConfigCluster{Name: "kubernetes", Cluster: clusterCert}}
+	userCert := KubeConfigUserCert{ClientCertificateData: base64.StdEncoding.EncodeToString([]byte(certPEM))}
+	users := []KubeConfigUser{KubeConfigUser{Name: "kubernetes-admin", User: userCert}}
+	k := KubeConfig{
+		Clusters: clusters,
+		Users:    users,
+	}
+	block, _ := pem.Decode([]byte(certPEM))
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, "", err
+	}
+	tmpFile, err := ioutil.TempFile(dir, filename)
+	if err != nil {
+		return nil, tmpFile.Name(), err
+	}
+	k.Path = tmpFile.Name()
+	d, err := yaml.Marshal(&k)
+	if err != nil {
+		return nil, tmpFile.Name(), err
+	}
+	if _, err := tmpFile.Write(d); err != nil {
+		return nil, tmpFile.Name(), err
+	}
+	if err := tmpFile.Close(); err != nil {
+		return nil, tmpFile.Name(), err
+	}
+
+	return cert, tmpFile.Name(), nil
+}
+
+// Check metrics
+func checkKubeconfigMetrics(cert *x509.Certificate, kubeconfig string, registry *prometheus.Registry, t *testing.T) {
+	mfs, err := registry.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ips := ","
+	for _, ip := range cert.IPAddresses {
+		ips = ips + ip.String() + ","
+	}
+	expectedResults := []*registryResult{
+		&registryResult{
+			Name: "ssl_kubeconfig_cert_not_after",
+			LabelValues: map[string]string{
+				"kubeconfig": kubeconfig,
+				"name":       "kubernetes",
+				"type":       "cluster",
+				"serial_no":  cert.SerialNumber.String(),
+				"issuer_cn":  cert.Issuer.CommonName,
+				"cn":         cert.Subject.CommonName,
+				"dnsnames":   "," + strings.Join(cert.DNSNames, ",") + ",",
+				"ips":        ips,
+				"emails":     "," + strings.Join(cert.EmailAddresses, ",") + ",",
+				"ou":         "," + strings.Join(cert.Subject.OrganizationalUnit, ",") + ",",
+			},
+			Value: float64(cert.NotAfter.Unix()),
+		},
+		&registryResult{
+			Name: "ssl_kubeconfig_cert_not_before",
+			LabelValues: map[string]string{
+				"kubeconfig": kubeconfig,
+				"name":       "kubernetes",
+				"type":       "cluster",
+				"serial_no":  cert.SerialNumber.String(),
+				"issuer_cn":  cert.Issuer.CommonName,
+				"cn":         cert.Subject.CommonName,
+				"dnsnames":   "," + strings.Join(cert.DNSNames, ",") + ",",
+				"ips":        ips,
+				"emails":     "," + strings.Join(cert.EmailAddresses, ",") + ",",
+				"ou":         "," + strings.Join(cert.Subject.OrganizationalUnit, ",") + ",",
+			},
+			Value: float64(cert.NotBefore.Unix()),
+		},
+		&registryResult{
+			Name: "ssl_kubeconfig_cert_not_after",
+			LabelValues: map[string]string{
+				"kubeconfig": kubeconfig,
+				"name":       "kubernetes-admin",
+				"type":       "user",
+				"serial_no":  cert.SerialNumber.String(),
+				"issuer_cn":  cert.Issuer.CommonName,
+				"cn":         cert.Subject.CommonName,
+				"dnsnames":   "," + strings.Join(cert.DNSNames, ",") + ",",
+				"ips":        ips,
+				"emails":     "," + strings.Join(cert.EmailAddresses, ",") + ",",
+				"ou":         "," + strings.Join(cert.Subject.OrganizationalUnit, ",") + ",",
+			},
+			Value: float64(cert.NotAfter.Unix()),
+		},
+		&registryResult{
+			Name: "ssl_kubeconfig_cert_not_before",
+			LabelValues: map[string]string{
+				"kubeconfig": kubeconfig,
+				"name":       "kubernetes-admin",
+				"type":       "user",
+				"serial_no":  cert.SerialNumber.String(),
+				"issuer_cn":  cert.Issuer.CommonName,
+				"cn":         cert.Subject.CommonName,
+				"dnsnames":   "," + strings.Join(cert.DNSNames, ",") + ",",
+				"ips":        ips,
+				"emails":     "," + strings.Join(cert.EmailAddresses, ",") + ",",
+				"ou":         "," + strings.Join(cert.Subject.OrganizationalUnit, ",") + ",",
+			},
+			Value: float64(cert.NotBefore.Unix()),
+		},
+	}
+	checkRegistryResults(expectedResults, mfs, t)
+}

--- a/prober/prober.go
+++ b/prober/prober.go
@@ -15,6 +15,7 @@ var (
 		"tcp":        ProbeTCP,
 		"file":       ProbeFile,
 		"kubernetes": ProbeKubernetes,
+		"kubeconfig": ProbeKubeconfig,
 	}
 )
 


### PR DESCRIPTION
The idea is to query the user certificate inside `/etc/kubernetes/admin.conf`.  Example output queried on my dev Kubernetes cluster:

```
$  curl "http://kubecontroller-dev:9219/probe?module=kubeconfig&target=/etc/kubernetes/admin.conf"
# HELP ssl_kubeconfig_cert_not_after NotAfter expressed as a Unix Epoch Time for a certificate found in a kubeconfig
# TYPE ssl_kubeconfig_cert_not_after gauge
ssl_kubeconfig_cert_not_after{cn="kubernetes",dnsnames="",emails="",ips="",issuer_cn="kubernetes",kubeconfig="/etc/kubernetes/admin.conf",name="kubernetes",ou="",serial_no="335833545820969761192653058045228355723340563282",type="cluster"} 1.73817534e+09
ssl_kubeconfig_cert_not_after{cn="kubernetes-admin",dnsnames="",emails="",ips="",issuer_cn="kubernetes",kubeconfig="/etc/kubernetes/admin.conf",name="kubernetes-admin",ou="",serial_no="3629461269801086488",type="user"} 1.63743128e+09
# HELP ssl_kubeconfig_cert_not_before NotBefore expressed as a Unix Epoch Time for a certificate found in a kubeconfig
# TYPE ssl_kubeconfig_cert_not_before gauge
ssl_kubeconfig_cert_not_before{cn="kubernetes",dnsnames="",emails="",ips="",issuer_cn="kubernetes",kubeconfig="/etc/kubernetes/admin.conf",name="kubernetes",ou="",serial_no="335833545820969761192653058045228355723340563282",type="cluster"} 1.58049534e+09
ssl_kubeconfig_cert_not_before{cn="kubernetes-admin",dnsnames="",emails="",ips="",issuer_cn="kubernetes",kubeconfig="/etc/kubernetes/admin.conf",name="kubernetes-admin",ou="",serial_no="3629461269801086488",type="user"} 1.58049534e+09
# HELP ssl_probe_success If the probe was a success
# TYPE ssl_probe_success gauge
ssl_probe_success 1
# HELP ssl_prober The prober used by the exporter to connect to the target
# TYPE ssl_prober gauge
ssl_prober{prober="kubeconfig"} 1
```

Also works to read kubelet configs and their associated certificates:

```
$  curl "http://kubeworker01-dev:9219/probe?module=kubeconfig&target=/etc/kubernetes/kubelet.conf"
# HELP ssl_kubeconfig_cert_not_after NotAfter expressed as a Unix Epoch Time for a certificate found in a kubeconfig
# TYPE ssl_kubeconfig_cert_not_after gauge
ssl_kubeconfig_cert_not_after{cn="kubernetes",dnsnames="",emails="",ips="",issuer_cn="kubernetes",kubeconfig="/etc/kubernetes/kubelet.conf",name="default-cluster",ou="",serial_no="335833545820969761192653058045228355723340563282",type="cluster"} 1.73817534e+09
ssl_kubeconfig_cert_not_after{cn="system:node:kubeworker01-dev",dnsnames="",emails="",ips="",issuer_cn="kubernetes",kubeconfig="/etc/kubernetes/kubelet.conf",name="default-auth",ou="",serial_no="158874210270431228542581699797837542620",type="user"} 1.637427849e+09
# HELP ssl_kubeconfig_cert_not_before NotBefore expressed as a Unix Epoch Time for a certificate found in a kubeconfig
# TYPE ssl_kubeconfig_cert_not_before gauge
ssl_kubeconfig_cert_not_before{cn="kubernetes",dnsnames="",emails="",ips="",issuer_cn="kubernetes",kubeconfig="/etc/kubernetes/kubelet.conf",name="default-cluster",ou="",serial_no="335833545820969761192653058045228355723340563282",type="cluster"} 1.58049534e+09
ssl_kubeconfig_cert_not_before{cn="system:node:kubeworker01-dev",dnsnames="",emails="",ips="",issuer_cn="kubernetes",kubeconfig="/etc/kubernetes/kubelet.conf",name="default-auth",ou="",serial_no="158874210270431228542581699797837542620",type="user"} 1.605891849e+09
# HELP ssl_probe_success If the probe was a success
# TYPE ssl_probe_success gauge
ssl_probe_success 1
# HELP ssl_prober The prober used by the exporter to connect to the target
# TYPE ssl_prober gauge
ssl_prober{prober="kubeconfig"} 1
```