### PR TITLE
[added] release target add loongarch64

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,7 @@ builds:
     goarch:
       - amd64
       - mips64le
+      - loongarch64
     flags:
       - -v
     ldflags: |


### PR DESCRIPTION
[added] release target add loongarch64

loongarch64 is Loongson's latest instruction set, and the server market has a lot of users in China.

PTAL.thanks。
@ribbybibby