### PR TITLE
Add support for postgresql protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ prober: <prober_string>
 ### <tcp_probe>
 
 ```
-# Use the STARTTLS command before starting TLS for those protocols that support it (smtp, ftp, imap)
+# Use the STARTTLS command before starting TLS for those protocols that support it (smtp, ftp, imap, postgres)
 [ starttls: <string> ]
 ```
 

--- a/prober/tcp_test.go
+++ b/prober/tcp_test.go
@@ -325,6 +325,45 @@ func TestProbeTCPStartTLSIMAP(t *testing.T) {
 	checkTLSVersionMetrics("TLS 1.3", registry, t)
 }
 
+// TestProbeTCPStartTLSPostgreSQL tests STARTTLS against a mock PostgreSQL server
+func TestProbeTCPStartTLSPostgreSQL(t *testing.T) {
+	server, certPEM, _, caFile, teardown, err := test.SetupTCPServer()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer teardown()
+
+	server.StartPostgreSQL()
+	defer server.Close()
+
+	module := config.Module{
+		TCP: config.TCPProbe{
+			StartTLS: "postgres",
+		},
+		TLSConfig: pconfig.TLSConfig{
+			CAFile:             caFile,
+			InsecureSkipVerify: false,
+		},
+	}
+
+	registry := prometheus.NewRegistry()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := ProbeTCP(ctx, newTestLogger(), server.Listener.Addr().String(), module, registry); err != nil {
+		t.Fatalf("error: %s", err)
+	}
+
+	cert, err := newCertificate(certPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkCertificateMetrics(cert, registry, t)
+	checkOCSPMetrics([]byte{}, registry, t)
+	checkTLSVersionMetrics("TLS 1.3", registry, t)
+}
+
 // TestProbeTCPTimeout tests that the TCP probe respects the timeout in the
 // context
 func TestProbeTCPTimeout(t *testing.T) {


### PR DESCRIPTION
With postgresql to initiate SSL-encrypted connection specific combination
of bytes must be sent to the server.

Message flow is described on following page
https://www.postgresql.org/docs/13/protocol-flow.html#id-1.10.5.7.11

And SSLRequest message format is described on
https://www.postgresql.org/docs/13/protocol-message-formats.html

The value of SSLRequest message becomes to bytes that is used in the code