### PR TITLE
Add helm-chart (#14)

### DIFF
--- a/charts/exporter/Chart.yaml
+++ b/charts/exporter/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ssl_exporter
+description: A Helm chart for SSL Exporter
+type: application
+version: 0.1.0
+appVersion: 2.3.1

--- a/charts/exporter/templates/_helpers.tpl
+++ b/charts/exporter/templates/_helpers.tpl
@@ -1,0 +1,39 @@
+{{/*****************************************************************************
+
+    General templates
+
+*****************************************************************************/}}
+
+{{- define "name" -}}{{- /******************************************************
+Expand the name of the chart
+***************************************************************************/ -}}
+{{- $.Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+
+{{- define "releasename" -}}{{- /**********************************************
+Expand the name of the instance
+***************************************************************************/ -}}
+{{- $.Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+
+{{- define "labels" -}}{{- /****************************************************
+Define controller labels
+***************************************************************************/ -}}
+app.kubernetes.io/name: {{ include "name" $ }}
+helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
+app.kubernetes.io/managed-by: {{ $.Release.Service }}
+app.kubernetes.io/instance: {{ $.Release.Name }}
+app.kubernetes.io/version: {{ $.Chart.AppVersion }}
+{{- end }}
+
+
+{{- define "matchLabels" -}}{{- /**********************************************
+	Define labels are used by controllers to find their pods
+***************************************************************************/ -}}
+app.kubernetes.io/name: {{ include "name" $ }}
+app.kubernetes.io/managed-by: {{ $.Release.Service }}
+app.kubernetes.io/instance: {{ $.Release.Name }}
+{{- end }}
+

--- a/charts/exporter/templates/deployment.yaml
+++ b/charts/exporter/templates/deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: {{ $.Release.Namespace | quote }}
+  name: {{ include "releasename" $ | quote }}
+  labels: {{- include "labels" $ | nindent 4 }}
+  annotations: {{- toYaml $.Values.annotations | nindent 4 }}
+spec:
+  selector:
+    matchLabels: {{- include "matchLabels" $ | nindent 6 }}
+  replicas: {{ int $.Values.replicaCount }}
+  strategy:
+    type: RollingUpdate
+  revisionHistoryLimit: 3
+
+  template:
+    metadata:
+      labels: {{- include "labels" $ | nindent 8 }}
+    spec:
+      restartPolicy: Always
+      terminationGracePeriodSeconds: {{ $.Values.terminationGracePeriodSeconds }}
+      nodeSelector: {{- toYaml $.Values.nodeSelector | nindent 8 }}
+      tolerations: {{- toYaml $.Values.tolerations | nindent 8 }}
+      affinity: {{- toYaml $.Values.affinity | nindent 8 }}
+      securityContext: {{- toYaml $.Values.securityContext | nindent 8 }}
+      imagePullSecrets: {{- toYaml $.Values.imagePullSecrets | nindent 8 }}
+      containers:
+
+        - name: exporter
+          image: ribbybibby/ssl-exporter:v{{ $.Chart.AppVersion }}
+          imagePullPolicy: {{ $.Values.podImagePullPolicy | quote }}
+          resources: {{ toYaml $.Values.resources | nindent 12 }}
+          ports:
+            - name: exporter
+              containerPort: 9219
+          readinessProbe:
+            {{- toYaml $.Values.probes.readiness | nindent 12 }}
+            httpGet:
+              port: exporter
+              path: /
+          livenessProbe:
+            {{- toYaml $.Values.probes.liveness | nindent 12 }}
+            httpGet:
+              port: exporter
+              path: /

--- a/charts/exporter/templates/prometheus-operator-probes/demo.yaml
+++ b/charts/exporter/templates/prometheus-operator-probes/demo.yaml
@@ -1,0 +1,17 @@
+{{- if $.Values.prometheusOperator.enableExampleProbes }}
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: probe-demo
+  labels:
+    release: prometheus-operator
+    {{- include "labels" $ | nindent 4 }}
+spec:
+  prober:
+    url: {{ printf "%s.%s.svc" (include "releasename" .) $.Release.Namespace | quote }}
+  module: http
+  targets:
+    staticConfig:
+      static:
+        - "https://demo.do.prometheus.io"
+{{- end }}

--- a/charts/exporter/templates/service.yaml
+++ b/charts/exporter/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ $.Release.Namespace | quote }}
+  name: {{ include "releasename" $ | quote }}
+  labels: {{- include "labels" $ | nindent 4 }}
+  annotations: {{- toYaml $.Values.service.annotations | nindent 4 }}
+spec:
+  ports:
+    - name: exporter
+      port: {{ $.Values.service.port }}
+      protocol: TCP
+      targetPort: exporter
+  selector: {{- include "matchLabels" $ | nindent 4 }}
+  sessionAffinity: {{ $.Values.service.sessionAffinity | quote }}
+  type: {{ $.Values.service.type | quote }}

--- a/charts/exporter/values.yaml
+++ b/charts/exporter/values.yaml
@@ -1,0 +1,41 @@
+annotations: {}
+replicaCount: 1
+imagePullPolicy: Always
+imagePullSecrets: []
+nodeSelector: {}
+tolerations: []
+affinity: {}
+securityContext: {}
+  # fsGroup: 1001
+  # runAsGroup: 1001
+  # runAsNonRoot: true
+  # runAsUser: 1001
+resources: {}
+  # limits:
+  #   cpu: 500m
+  #   memory: 256Mi
+  # requests:
+  #   cpu: 200m
+  #   memory: 128Mi
+terminationGracePeriodSeconds: 5
+probes:
+  readiness:
+    initialDelaySeconds: 3
+    periodSeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+  liveness:
+    initialDelaySeconds: 3
+    periodSeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 3
+    successThreshold: 1
+service:
+  enabled: true
+  annotations: {}
+  port: 80
+  sessionAffinity: None
+
+prometheusOperator:
+  enableExampleProbes: false


### PR DESCRIPTION
Hi. I've added simple helm chart. It makes available to deploy it to Kubernetes with Prometheus Operator compatibility (Config is being declared as Probes).

I've checked it on Kubernetes 1.19