### PR TITLE
Report revocation status for every certificate

### DIFF
--- a/prober/https.go
+++ b/prober/https.go
@@ -17,7 +17,7 @@ import (
 
 // ProbeHTTPS performs a https probe
 func ProbeHTTPS(ctx context.Context, logger log.Logger, target string, module config.Module, registry *prometheus.Registry) error {
-	tlsConfig, err := newTLSConfig("", registry, &module.TLSConfig)
+	tlsConfig, err := newTLSConfig(logger, "", registry, &module.TLSConfig)
 	if err != nil {
 		return err
 	}

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -18,7 +18,7 @@ import (
 
 // ProbeTCP performs a tcp probe
 func ProbeTCP(ctx context.Context, logger log.Logger, target string, module config.Module, registry *prometheus.Registry) error {
-	tlsConfig, err := newTLSConfig(target, registry, &module.TLSConfig)
+	tlsConfig, err := newTLSConfig(logger, target, registry, &module.TLSConfig)
 	if err != nil {
 		return err
 	}

--- a/prober/tls.go
+++ b/prober/tls.go
@@ -6,13 +6,14 @@ import (
 	"encoding/pem"
 	"net"
 
+	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	pconfig "github.com/prometheus/common/config"
 )
 
 // newTLSConfig sets up TLS config and instruments it with a function that
 // collects metrics for the verified chain
-func newTLSConfig(target string, registry *prometheus.Registry, pTLSConfig *pconfig.TLSConfig) (*tls.Config, error) {
+func newTLSConfig(logger log.Logger, target string, registry *prometheus.Registry, pTLSConfig *pconfig.TLSConfig) (*tls.Config, error) {
 	tlsConfig, err := pconfig.NewTLSConfig(pTLSConfig)
 	if err != nil {
 		return nil, err
@@ -27,7 +28,7 @@ func newTLSConfig(target string, registry *prometheus.Registry, pTLSConfig *pcon
 	}
 
 	tlsConfig.VerifyConnection = func(state tls.ConnectionState) error {
-		return collectConnectionStateMetrics(state, registry)
+		return collectConnectionStateMetrics(logger, state, registry)
 	}
 
 	return tlsConfig, nil


### PR DESCRIPTION
This adds a new metric `ssl_revocation_status` for each certificate in every trusted chains. This metrics shows whether the certificate is marked as revoked on OCSP responders or (if available as a fallback) in the CA’s CRL.

OSCP response are cached for 6 hours to avoid putting to much load on responders.

Implements #63 