### PR TITLE
added pop3 STARTTLS queryResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ prober: <prober_string>
 ### <tcp_probe>
 
 ```
-# Use the STARTTLS command before starting TLS for those protocols that support it (smtp, ftp, imap, postgres)
+# Use the STARTTLS command before starting TLS for those protocols that support it (smtp, ftp, imap, pop3, postgres)
 [ starttls: <string> ]
 ```
 

--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -119,6 +119,17 @@ var (
 				expectBytes: []byte{0x53},
 			},
 		},
+		"pop3": []queryResponse{
+			queryResponse{
+				expect: "OK",
+			},
+			queryResponse{
+				send: "STLS",
+			},
+			queryResponse{
+				expect: "OK",
+			},
+		},
 	}
 )
 


### PR DESCRIPTION
Relating to RFC https://datatracker.ietf.org/doc/html/rfc2595#section-4, we created a pop3 starttls query. Hopefully this will be included in your ssl-exporter to implement POP3 starttls probes.

Do you need any tests to prove the function?

##### without patch
```
tb@tb ~/git/ssl_exporter $ curl 'http://127.0.0.1:9219/probe?module=starttls_pop3&target=xxxxx%3A110'
# HELP ssl_probe_success If the probe was a success
# TYPE ssl_probe_success gauge
ssl_probe_success 0
# HELP ssl_prober The prober used by the exporter to connect to the target
# TYPE ssl_prober gauge
ssl_prober{prober="tcp"} 1

level=error ts=2021-12-09T10:18:55.817Z caller=ssl_exporter.go:99 target=xxxxx:110 prober=tcp timeout=10s msg="STARTTLS is not supported for pop3"
```

##### with patch (cut off)
```
tb@tb ~/git/ssl_exporter $ curl 'http://127.0.0.1:9219/probe?module=starttls_pop3&target=xxxxx%3A110'
....
# HELP ssl_probe_success If the probe was a success
# TYPE ssl_probe_success gauge
ssl_probe_success 1
# HELP ssl_prober The prober used by the exporter to connect to the target
# TYPE ssl_prober gauge
ssl_prober{prober="tcp"} 1
# HELP ssl_tls_version_info The TLS version used
# TYPE ssl_tls_version_info gauge
ssl_tls_version_info{version="TLS 1.2"} 1
# HELP ssl_verified_cert_not_after NotAfter expressed as a Unix Epoch Time
# TYPE ssl_verified_cert_not_after gauge
ssl_verified_cert_not_after{chain_no="0",cn="ISRG Root X1",dnsnames="",emails="",ips="",issuer_cn="ISRG Root X1",ou="",serial_no="172886928669790476064670243504169061120"} 2.064567878e+09
ssl_verified_cert_not_after{chain_no="0",cn="R3",dnsnames="",emails="",ips="",issuer_cn="ISRG Root X1",ou="",serial_no="192961496339968674994309121183282847578"} 1.757952e+09
ssl_verified_cert_not_after{chain_no="0",cn="xxxxx",dnsnames="xxxxx",emails="",ips="",issuer_cn="R3",ou="",serial_no="3842xxxxx"} 1.642294402e+09
# HELP ssl_verified_cert_not_before NotBefore expressed as a Unix Epoch Time
# TYPE ssl_verified_cert_not_before gauge
ssl_verified_cert_not_before{chain_no="0",cn="ISRG Root X1",dnsnames="",emails="",ips="",issuer_cn="ISRG Root X1",ou="",serial_no="172886928669790476064670243504169061120"} 1.433415878e+09
ssl_verified_cert_not_before{chain_no="0",cn="R3",dnsnames="",emails="",ips="",issuer_cn="ISRG Root X1",ou="",serial_no="192961496339968674994309121183282847578"} 1.5991776e+09
ssl_verified_cert_not_before{chain_no="0",cn="xxxxx",dnsnames="xxxxx",emails="",ips="",issuer_cn="R3",ou="",serial_no="xxxxx"} 1.634518403e+09
```

##### configuration

```
modules:
  starttls_pop3:
    prober: tcp
    tcp:
      starttls: pop3
```
