### PR TITLE
feature: OCSP prober

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Exports metrics for certificates collected from various sources:
 - [TCP probes](#tcp)
 - [HTTPS probes](#https)
+- [OCSP probes](#ocsp)
 - [PEM files](#file)
 - [Kubernetes secrets](#kubernetes)
 - [Kubeconfig files](#kubeconfig)
@@ -134,6 +135,39 @@ This will use proxy servers discovered by the environment variables `HTTP_PROXY`
 configuration.
 
 The latter takes precedence.
+
+### OCSP
+
+The exporter will make a HTTP connection to the target, sending an
+[OCSP](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol) request
+to the specified path, verifying the supplied certificate with the supplied
+issuing certificate.  By providing both certificates (vs. downloading the
+issuing certificate via the Issuing Certificate URL specified in the client
+certificate) we limit our testing to just the OCSP validation service instead of
+having a path depend on being able to retrieve the issuing certificate.
+
+This will return just `ssl_ocsp...` metrics, as OCSP responders communicate over
+plain HTTP.
+
+```yml
+scrape_configs:
+  - job_name: "ocsp"
+    metrics_path: /probe
+    params:
+      module: ["ocsp"]
+    static_configs:
+      - targets:
+          - ocspresponder1.example.com
+          - ocspresponder2.example.com
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: 127.0.0.1:9219
+```
+
 
 ### File
 
@@ -323,6 +357,19 @@ target: <string>
 ```
 # HTTP proxy server to use to connect to the targets.
 [ proxy_url: <string> ]
+```
+
+### <ocsp_probe>
+
+```
+# The client certificate to check vs. the OCSP responder
+[ client_cert: <filename> ]
+
+# The issuing certificate which signed the client_cert
+[ issuing_cert: <filename> ]
+
+# path on the target to the OCSP responder (e.g., '/ocsp')
+[ path: <string> ]
 ```
 
 ### <tcp_probe>

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,9 @@ var (
 			"tcp": Module{
 				Prober: "tcp",
 			},
+			"ocsp": Module{
+				Prober: "ocsp",
+			},
 			"http": Module{
 				Prober: "https",
 			},
@@ -72,6 +75,7 @@ type Module struct {
 	TLSConfig  TLSConfig       `yaml:"tls_config,omitempty"`
 	HTTPS      HTTPSProbe      `yaml:"https,omitempty"`
 	TCP        TCPProbe        `yaml:"tcp,omitempty"`
+	OCSP       OCSPProbe       `yaml:"ocsp,omitempty"`
 	Kubernetes KubernetesProbe `yaml:"kubernetes,omitempty"`
 }
 
@@ -130,6 +134,13 @@ func NewTLSConfig(cfg *TLSConfig) (*tls.Config, error) {
 // TCPProbe configures a tcp probe
 type TCPProbe struct {
 	StartTLS string `yaml:"starttls,omitempty"`
+}
+
+// OCSPProbe configures a ocsp probe
+type OCSPProbe struct {
+	ClientCert  string `yaml:"client_cert"`
+	IssuingCert string `yaml:"issuing_cert,omitempty"`
+	Path        string `yaml:"path,omitempty"`
 }
 
 // HTTPSProbe configures a https probe

--- a/examples/ssl_exporter.yaml
+++ b/examples/ssl_exporter.yaml
@@ -46,3 +46,9 @@ modules:
       kubeconfig: /root/.kube/config
   kubeconfig:
     prober: kubeconfig
+  ocsp:
+    prober: ocsp
+    ocsp:
+      client_cert: /etc/ssl/certs/CompanyServerCA.pem
+      issuing_cert: /etc/ssl/certs/CompanyRoot.pem
+      path: /ocsp

--- a/prober/ocsp.go
+++ b/prober/ocsp.go
@@ -1,0 +1,99 @@
+package prober
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/ribbybibby/ssl_exporter/v2/config"
+	"golang.org/x/crypto/ocsp"
+)
+
+// ProbeOCSP performs a OCSP probe
+func ProbeOCSP(ctx context.Context, logger log.Logger, target string, module config.Module, registry *prometheus.Registry) error {
+	cert, err := readCert(module.OCSP.ClientCert)
+	if err != nil {
+		return err
+	}
+
+	issuerCert, err := readCert(module.OCSP.IssuingCert)
+	if err != nil {
+		return err
+	}
+
+	ocspURL := "http://" + target + module.OCSP.Path
+
+	buffer, err := ocsp.CreateRequest(cert, issuerCert, &ocsp.RequestOptions{
+		Hash: crypto.SHA1,
+	})
+	if err != nil {
+		return fmt.Errorf("creating ocsp request body: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, ocspURL, bytes.NewBuffer(buffer))
+	if err != nil {
+		return fmt.Errorf("creating http request: %w", err)
+	}
+
+	ocspUrl, err := url.Parse(ocspURL)
+	if err != nil {
+		return fmt.Errorf("parsing ocsp url: %w", err)
+	}
+
+	req.Header.Add("Content-Type", "application/ocsp-request")
+	req.Header.Add("Accept", "application/ocsp-response")
+	req.Header.Add("host", ocspUrl.Host)
+	req = req.WithContext(ctx)
+
+	// Make OCSP request
+	httpResponse, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("making ocsp request: %w", err)
+	}
+
+	defer httpResponse.Body.Close()
+
+	output, err := ioutil.ReadAll(httpResponse.Body)
+	if err != nil {
+		return fmt.Errorf("reading response body: %w", err)
+	}
+
+	return collectOCSPMetrics(output, registry)
+}
+
+func readCert(path string) (*x509.Certificate, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening %s: %w", path, err)
+	}
+
+	defer file.Close()
+
+	b, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	// PEM to DER
+	block, _ := pem.Decode([]byte(b))
+	if block == nil {
+		panic("failed to parse certificate PEM")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing certificate %s: %w", path, err)
+	}
+
+	return cert, nil
+}

--- a/prober/prober.go
+++ b/prober/prober.go
@@ -14,6 +14,7 @@ var (
 		"https":      ProbeHTTPS,
 		"http":       ProbeHTTPS,
 		"tcp":        ProbeTCP,
+		"ocsp":       ProbeOCSP,
 		"file":       ProbeFile,
 		"kubernetes": ProbeKubernetes,
 		"kubeconfig": ProbeKubeconfig,


### PR DESCRIPTION
Add OCSP prober for checking OCSP responders.

This will make an OCSP request to the target, using the supplied certificates (a certificate to be checked and the certificate that signed it).  We supply the issuing cert so we're limiting our testing to just the responder vs. testing whether the issuing cert can be downloaded via the 'Issuing Certificate URL' specified in the client cert.

Will return just the ssl_ocsp* metrics.

This allows you to confirm OCSP responders are functional.