### PR TITLE
Set numeric user to comply runAsNonRoot k8s policy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,12 @@
 FROM alpine:3.15 as build
 RUN apk --update add ca-certificates
-RUN echo "ssl:*:100:ssl" > /tmp/group && \
-    echo "ssl:*:100:100::/:/ssl_exporter" > /tmp/passwd
-
 
 FROM scratch
 
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=build /tmp/group \
-    /tmp/passwd \
-    /etc/
 COPY ssl_exporter /
 
-USER ssl:ssl
+USER 10001
+
 EXPOSE 9219/tcp
 ENTRYPOINT ["/ssl_exporter"]


### PR DESCRIPTION
When in k8s, container has `runAsNonRoot` policy and image has non-numeric user (nobody), then the deployment will fail as it cannot verify user is non-root.

Fixed #102

Signed-off-by: Julio Damasceno <xjulio@gmail.com>