### PR TITLE
Fix Dockerfile.local

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM golang:1.15-buster AS build
+FROM golang:1.18-buster AS build
 
 ADD . /tmp/ssl_exporter
 


### PR DESCRIPTION
Hi,

This patch fix the error when we use *Dockerfile.local* to build the docker image :

```
/go/pkg/mod/k8s.io/client-go@v0.24.0/plugin/pkg/client/auth/exec/metrics.go:21:2: package io/fs is not in GOROOT (/usr/local/go/src/io/fs)
make: *** [Makefile:32: vet] Error 1
The command '/bin/sh -c cd /tmp/ssl_exporter &&     echo "ssl:*:100:ssl" > group &&     echo "ssl:*:100:100::/:/ssl_exporter" > passwd &&     make' returned a non-zero code: 2
```

Have a nice day