### PR TITLE
[tcp-prober] update regex for STARTTLS response

### DIFF
--- a/prober/tcp.go
+++ b/prober/tcp.go
@@ -71,7 +71,7 @@ var (
 				send: "EHLO prober",
 			},
 			queryResponse{
-				expect: "^250-STARTTLS",
+				expect: "^250(-| )STARTTLS",
 			},
 			queryResponse{
 				send: "STARTTLS",


### PR DESCRIPTION
The response to an EHLO probe can be split with either a '-' or a space character (' ') according to the RFC (https://datatracker.ietf.org/doc/html/rfc1869#section-4.3), so both "250 STARTTLS" and "250-STARTTLS" are valid. The regular expression should therefore match both variants.