### PR TITLE
fix: support parsing of openssl specific trusted cert formats

### DIFF
--- a/prober/tls.go
+++ b/prober/tls.go
@@ -57,7 +57,7 @@ func contains(certs []*x509.Certificate, cert *x509.Certificate) bool {
 func decodeCertificates(data []byte) ([]*x509.Certificate, error) {
 	var certs []*x509.Certificate
 	for block, rest := pem.Decode(data); block != nil; block, rest = pem.Decode(rest) {
-		if block.Type == "CERTIFICATE" {
+		if block.Type == "CERTIFICATE" || block.Type == "TRUSTED CERTIFICATE" {
 			cert, err := x509.ParseCertificate(block.Bytes)
 			if err != nil {
 				return certs, err


### PR DESCRIPTION
There is an openssl specific format, which includes additional trust rules in cert itself.
Such certificates have different block.Type "TRUSTED CERTIFICATE" instead of "CERTIFICATE". Would be nice to support this in exporter.

More details below:
- https://stackoverflow.com/questions/55447752/what-does-begin-trusted-certificate-in-a-certificate-mean
- https://www.openssl.org/docs/man3.0/man1/openssl-verification-options.html