### PR TITLE
fix description

### DIFF
--- a/contrib/grafana/dashboard.json
+++ b/contrib/grafana/dashboard.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "Shows certitificate expiration times, as well as failed ssl connects",
+  "description": "Shows certificate expiration times, as well as failed ssl connects",
   "editable": true,
   "gnetId": 11279,
   "graphTooltip": 0,


### PR DESCRIPTION
Fix double "ti" in certificate in description of dashboard