### PR TITLE
Add docker compose.compose.yml example + add 2nd Prometheus scrape_configs example without Kubernetes - local only

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,27 @@ scrape_configs:
         target_label: __address__
         replacement: ${1}:9219
 ```
+Another Prometheus scrape-config example for usage of this "file" prober to check the expiry of local certificate files without Kubernetes:
+
+```yml
+scrape_configs:
+  - job_name: 'ssl-local-file'
+    scrape_interval: 60s
+    static_configs:
+      - targets:
+        - /etc/easyrsa/pki/*.crt   # example for easyrsa .crt files
+        - /etc/easyrsa/pki/issued/*.crt   # example for easyrsa .crt files
+    metrics_path: /probe
+    params:
+      module: [file]
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: 127.0.0.1:9219  # The exporter's real hostname:port
+```
 
 ### HTTP File
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+# example docker compose file
+services:
+  exporter:
+    image: ribbybibby/ssl-exporter:latest # or use specific version e.g. ribbybibby/ssl-exporter:2.4.3
+    command: --web.listen-address=":9219" --log.level="info"
+    restart: always
+    user: 0:0 # UID:GID - attention: user/group need read permissions to SSL-certificate files to be checked
+    #volumes:
+    #  - /etc/easyrsa/pki/issued:/mnt/ssl-certs:ro 
+    ports:
+      - 9219:9219
+    #logging:
+      #driver: none


### PR DESCRIPTION
Added a docker-compose.yml example file and added a 2nd Prometheus scrape_configs example without Kubernetes dependency for local only checks in README.md

Best regards
Michael Schmaltz